### PR TITLE
add references to standard-app-packages and accounts-base for 0.6.5 deployments

### DIFF
--- a/package.js
+++ b/package.js
@@ -5,6 +5,9 @@ Package.describe({
 var both = ['client', 'server']
 
 Package.on_use(function (api) {
+	api.use('standard-app-packages');
+        api.use('accounts-base');
+    
 	api.add_files(['client.js'], 'client');
 	api.add_files(['server.js'], 'server');
 	api.add_files(['common.js'], both);


### PR DESCRIPTION
Another small fix to enable support for Meteor 0.6.5+.  I was getting the following errors without these api.use statements.  

```
TypeError: Object # has no method 'methods'
TypeError: Cannot call method 'find' of undefined
```
