### PR TITLE
Remove call to method that doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 ## Event Hooks - Meteor Smart Package
 
-[![endorse](https://api.coderwall.com/benjaminrh/endorsecount.png)](https://coderwall.com/benjaminrh)
-
 Provides hooks for various user-triggered events.
-
 
 ### API
 
@@ -17,11 +14,9 @@ Currently, all API methods on the server take a `userId` argument.
  * `Hooks.onGainFocus = function ([server: userId]) { ... }` ( _anywhere_ )* - Provide a callback to run when the window gains focus * Opt-in through the `updateFocus` option
  * `Hooks.onCloseSession = function ([server: userId]) { ... }` ( _server_ ) - Provide a callback to run when the window/tab is closed
 
-
 ### Initialization
 
  * `Hooks.init([options])` ( _client_ ) - Initialize the event system. Optionally provide an `Object` to set the options. Put this in your `Meteor.startup`
-
 
 ### Options
 
@@ -29,7 +24,6 @@ Options are specified on the client side as an argument (object) in the `init` m
 
  * `updateFocus` ( _Integer_ ) - Number of milliseconds to wait before checking whether the window is focused. Default is `0`, meaning unless you change this, the `onLoseFocus` and `onGainFocus` methods won't be available
  * `treatCloseAsLogout` ( _Boolean_ ) - If true, treat closing the browser window as logging off (meaning that the `onLoggedOut` callback is triggered in addition to the `onCloseSession`). Default is `false`
-
 
 ### How to use?
 
@@ -44,5 +38,3 @@ if(Meteor.isClient){
 	});
 }
 ```
-
-That's it!

--- a/client.js
+++ b/client.js
@@ -42,9 +42,6 @@ Hooks = {
 		//= BASIC INITIALIZATION
 		//////////////////////////////////
 
-		// Fire up the server
-		Meteor.call('eventsOnHooksInit');
-
 		// Initialize options
 		if (typeof options !== 'undefined') {
 			if (options.updateFocus) Hooks.updateFocus = options.updateFocus;
@@ -71,7 +68,7 @@ Hooks = {
 			}
 		}
 
-		
+
 
 		//////////////////////////////////
 		//= SETUP LOGIN MONITORING

--- a/package.js
+++ b/package.js
@@ -1,5 +1,8 @@
 Package.describe({
-	summary: "Provides hooks for various user-triggered events"
+	name: "differential:event-hooks",
+	summary: "Provides hooks for various user-triggered events",
+	git: 'https://github.com/Differential/meteor-event-hooks.git',
+	version: '1.5.0'
 });
 
 var both = ['client', 'server']

--- a/package.js
+++ b/package.js
@@ -4,10 +4,12 @@ Package.describe({
 
 var both = ['client', 'server']
 
-Package.on_use(function (api) {
-	api.add_files(['client.js'], 'client');
-	api.add_files(['server.js'], 'server');
-	api.add_files(['common.js'], both);
+Package.onUse(function (api) {
+  api.versionsFrom("METEOR@0.9.0");
+
+	api.addFiles(['client.js'], 'client');
+	api.addFiles(['server.js'], 'server');
+	api.addFiles(['common.js'], both);
 
 	if (typeof api.export !== 'undefined') {
 		api.export(['Hooks', 'EventHooksMonitoringCollection'], both);

--- a/smart.json
+++ b/smart.json
@@ -1,9 +1,0 @@
-{
-	"name": "event-hooks",
-	"description": "Provides hooks for various user-triggered events",
-	"homepage": "https://github.com/BenjaminRH/meteor-event-hooks",
-	"author": "Benjamin Harris  (http://benjaminrharris.com)",
-	"version": "1.4.3",
-	"git": "https://github.com/BenjaminRH/meteor-event-hooks.git",
-	"packages": {}
-}

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,15 @@
+{
+  "dependencies": [
+    [
+      "meteor",
+      "1.1.3"
+    ],
+    [
+      "underscore",
+      "1.0.1"
+    ]
+  ],
+  "pluginDependencies": [],
+  "toolVersion": "meteor-tool@1.0.36",
+  "format": "1.0"
+}


### PR DESCRIPTION
Was getting an error in Meteor APM — looks like the package calls 'eventsOnHooksInit' method which doesn't seem to exist.

Am I missing something?
